### PR TITLE
Cleanup

### DIFF
--- a/src/libhttpd.c
+++ b/src/libhttpd.c
@@ -201,23 +201,16 @@ check_options( void )
 
 static void
 free_httpd_server( httpd_server* hs )
-    {
-    if ( hs->binding_hostname != (char*) 0 )
-	free( (void*) hs->binding_hostname );
-    if ( hs->cwd != (char*) 0 )
-	free( (void*) hs->cwd );
-    if ( hs->cgi_pattern != (char*) 0 )
-	free( (void*) hs->cgi_pattern );
-    if ( hs->charset != (char*) 0 )
-	free( (void*) hs->charset );
-    if ( hs->p3p != (char*) 0 )
-	free( (void*) hs->p3p );
-    if ( hs->url_pattern != (char*) 0 )
-	free( (void*) hs->url_pattern );
-    if ( hs->local_pattern != (char*) 0 )
-	free( (void*) hs->local_pattern );
-    free( (void*) hs );
-    }
+{
+    free(hs->binding_hostname);
+    free(hs->cwd);
+    free(hs->cgi_pattern);
+    free(hs->charset);
+    free(hs->p3p);
+    free(hs->url_pattern);
+    free(hs->local_pattern);
+    free(hs);
+}
 
 
 httpd_server*
@@ -2464,28 +2457,27 @@ httpd_close_conn( httpd_conn* hc, struct timeval* nowP )
 
 void
 httpd_destroy_conn( httpd_conn* hc )
-    {
-    if ( hc->initialized )
-	{
-	free( (void*) hc->read_buf );
-	free( (void*) hc->decodedurl );
-	free( (void*) hc->origfilename );
-	free( (void*) hc->expnfilename );
-	free( (void*) hc->encodings );
-	free( (void*) hc->pathinfo );
-	free( (void*) hc->query );
-	free( (void*) hc->accept );
-	free( (void*) hc->accepte );
-	free( (void*) hc->reqhost );
-	free( (void*) hc->hostdir );
-	free( (void*) hc->remoteuser );
-	free( (void*) hc->response );
+{
+    if (hc->initialized) {
+	free(hc->read_buf);
+	free(hc->decodedurl);
+	free(hc->origfilename);
+	free(hc->expnfilename);
+	free(hc->encodings);
+	free(hc->pathinfo);
+	free(hc->query);
+	free(hc->accept);
+	free(hc->accepte);
+	free(hc->reqhost);
+	free(hc->hostdir);
+	free(hc->remoteuser);
+	free(hc->response);
 #ifdef TILDE_MAP_2
-	free( (void*) hc->altdir );
+	free(hc->altdir);
 #endif /* TILDE_MAP_2 */
 	hc->initialized = 0;
-	}
     }
+}
 
 
 struct mime_entry {

--- a/src/mmc.c
+++ b/src/mmc.c
@@ -208,7 +208,7 @@ mmc_map( char* filename, struct stat* sbP, struct timeval* nowP )
 	    {
 	    syslog( LOG_ERR, "mmap - %m" );
 	    (void) close( fd );
-	    free( (void*) m );
+	    free(m);
 	    --alloc_count;
 	    return (void*) 0;
 	    }
@@ -227,7 +227,7 @@ mmc_map( char* filename, struct stat* sbP, struct timeval* nowP )
 	    {
 	    syslog( LOG_ERR, "out of memory storing a file" );
 	    (void) close( fd );
-	    free( (void*) m );
+	    free(m);
 	    --alloc_count;
 	    return (void*) 0;
 	    }
@@ -235,7 +235,7 @@ mmc_map( char* filename, struct stat* sbP, struct timeval* nowP )
 	    {
 	    syslog( LOG_ERR, "read - %m" );
 	    (void) close( fd );
-	    free( (void*) m );
+	    free(m);
 	    --alloc_count;
 	    return (void*) 0;
 	    }
@@ -247,7 +247,7 @@ mmc_map( char* filename, struct stat* sbP, struct timeval* nowP )
     if ( add_hash( m ) < 0 )
 	{
 	syslog( LOG_ERR, "add_hash() failure" );
-	free( (void*) m );
+	free(m);
 	--alloc_count;
 	return (void*) 0;
 	}
@@ -336,7 +336,7 @@ mmc_cleanup( struct timeval* nowP )
 	m = free_maps;
 	free_maps = m->next;
 	--free_count;
-	free( (void*) m );
+	free(m);
 	--alloc_count;
 	}
     }
@@ -374,7 +374,7 @@ really_unmap( Map** mm )
 	if ( munmap( m->addr, m->size ) < 0 )
 	    syslog( LOG_ERR, "munmap - %m" );
 #else /* HAVE_MMAP */
-	free( (void*) m->addr );
+	free(m->addr);
 #endif /* HAVE_MMAP */
 	}
     /* Update the total byte count. */
@@ -404,7 +404,7 @@ mmc_destroy( void )
 	m = free_maps;
 	free_maps = m->next;
 	--free_count;
-	free( (void*) m );
+	free(m);
 	--alloc_count;
 	}
     }
@@ -429,7 +429,7 @@ check_hash_size( void )
     else
 	{
 	/* No, got to expand. */
-	free( (void*) hash_table );
+	free(hash_table);
 	/* Double the hash size until it's big enough. */
 	do
 	    {

--- a/src/thttpd.c
+++ b/src/thttpd.c
@@ -1477,7 +1477,7 @@ shut_down( void )
 	if ( connects[cnum].hc != (httpd_conn*) 0 )
 	    {
 	    httpd_destroy_conn( connects[cnum].hc );
-	    free( (void*) connects[cnum].hc );
+	    free(connects[cnum].hc);
 	    --httpd_conn_count;
 	    connects[cnum].hc = (httpd_conn*) 0;
 	    }
@@ -1494,9 +1494,9 @@ shut_down( void )
 	}
     mmc_destroy();
     tmr_destroy();
-    free( (void*) connects );
+    free(connects);
     if ( throttles != (throttletab*) 0 )
-	free( (void*) throttles );
+	free(throttles);
     }
 
 

--- a/src/timers.c
+++ b/src/timers.c
@@ -349,7 +349,7 @@ tmr_cleanup( void )
 	t = free_timers;
 	free_timers = t->next;
 	--free_count;
-	free( (void*) t );
+	free(t);
 	--alloc_count;
 	}
     }


### PR DESCRIPTION
`free()` is NULL-safe on any remotely (and I mean **remotely**) modern system. I made a few style fixes to adjacent code too. More to come.