### PR TITLE
Fix heap buffer overflow in de_dotdot

### DIFF
--- a/src/libhttpd.c
+++ b/src/libhttpd.c
@@ -2410,7 +2410,7 @@ de_dotdot( char* file )
     while ( strncmp( file, "./", 2 ) == 0 )
 	(void) memmove( file, file + 2, strlen( file ) - 1 );
     while ( ( cp = strstr( file, "/./") ) != (char*) 0 )
-	(void) memmove( cp, cp + 2, strlen( file ) - 1 );
+	(void) memmove( cp, cp + 2, strlen( cp ) - 1 );
 
     /* Alternate between removing leading ../ and removing xxx/../ */
     for (;;)


### PR DESCRIPTION
A heap buffer overflow was introduced after switching some strcpy calls to memmove. The length of a memmove was computed incorrectly, leading to an overflow. This PR fixes the length computation.