### PR TITLE
Convert man pages to utf8.

### DIFF
--- a/docs/makeweb.1
+++ b/docs/makeweb.1
@@ -10,7 +10,7 @@ of the main web directory.
 .SH "SEE ALSO
 thttpd(8)
 .SH AUTHOR
-Copyright © 1995 by Jef Poskanzer <jef@mail.acme.com>.
+Copyright Â© 1995 by Jef Poskanzer <jef@mail.acme.com>.
 All rights reserved.
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions

--- a/docs/redirect.8
+++ b/docs/redirect.8
@@ -55,7 +55,7 @@ The wildcard mechanism is very primitive.
 In particular, any characters that follow the asterisk are blithely
 ignored.
 .SH AUTHOR
-Copyright © 1995 by Jef Poskanzer <jef@mail.acme.com>.
+Copyright Â© 1995 by Jef Poskanzer <jef@mail.acme.com>.
 All rights reserved.
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions

--- a/docs/ssi.8
+++ b/docs/ssi.8
@@ -118,7 +118,7 @@ Actually, I consider this neither a bug nor a deficiency, but some may.
 .SH "SEE ALSO"
 thttpd(8), strftime(3)
 .SH AUTHOR
-Copyright © 1995 by Jef Poskanzer <jef@mail.acme.com>.
+Copyright Â© 1995 by Jef Poskanzer <jef@mail.acme.com>.
 All rights reserved.
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions

--- a/docs/syslogtocern.8
+++ b/docs/syslogtocern.8
@@ -21,7 +21,7 @@ It ought to produce separate files for each, identified by IP address and
 port number.
 However, that change represents a huge increase in complexity, so next version.
 .SH AUTHOR
-Copyright © 1995 by Jef Poskanzer <jef@mail.acme.com>.
+Copyright Â© 1995 by Jef Poskanzer <jef@mail.acme.com>.
 All rights reserved.
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions

--- a/docs/thttpd.8
+++ b/docs/thttpd.8
@@ -572,7 +572,7 @@ Catalin Ionescu.
 Special thanks to Craig Leres for substantial debugging and development,
 and for not complaining about my coding style very much.
 .SH AUTHOR
-Copyright © 1995,1998,1999,2000 by Jef Poskanzer <jef@mail.acme.com>.
+Copyright Â© 1995,1998,1999,2000 by Jef Poskanzer <jef@mail.acme.com>.
 All rights reserved.
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions


### PR DESCRIPTION
The man pages are in iso8859-1 encoding.  This converts them into
UTF8 text for better compatibility with modern systems.