### PR TITLE
Fix GCC build warnings.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,8 @@ AN_PROGRAM([ar], [AC_PROG_AR])
 AC_DEFUN([AC_PROG_AR], [AC_CHECK_TOOL(AR, ar, :)])
 AC_PROG_AR
 
+AC_USE_SYSTEM_EXTENSIONS
+
 # Checks for libraries.
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_LIB(rt, clock_gettime)

--- a/src/libhttpd.c
+++ b/src/libhttpd.c
@@ -2914,7 +2914,7 @@ mode  links  bytes  last-changed  name\n\
 
 		/* And print. */
 		(void)  fprintf( fp,
-		   "%s %3ld  %10lld  %s  <A HREF=\"/%.500s%s\">%.80s</A>%s%s%s\n",
+		   "%s %3ld  %10ld  %s  <A HREF=\"/%.500s%s\">%.80s</A>%s%s%s\n",
 		    modestr, (long) lsb.st_nlink, (int64_t) lsb.st_size,
 		    timestr, encrname, S_ISDIR(sb.st_mode) ? "/" : "",
 		    nameptrs[i], linkprefix, link, fileclass );

--- a/src/mmc.c
+++ b/src/mmc.c
@@ -521,7 +521,7 @@ void
 mmc_logstats( long secs )
     {
     syslog(
-	LOG_INFO, "  map cache - %d allocated, %d active (%lld bytes), %d free; hash size: %d; expire age: %ld",
+	LOG_INFO, "  map cache - %d allocated, %d active (%ld bytes), %d free; hash size: %d; expire age: %ld",
 	alloc_count, map_count, (int64_t) mapped_bytes, free_count, hash_size,
 	expire_age );
     if ( map_count + free_count != alloc_count )

--- a/src/thttpd.c
+++ b/src/thttpd.c
@@ -2179,7 +2179,7 @@ thttpd_logstats( long secs )
     {
     if ( secs > 0 )
 	syslog( LOG_INFO,
-	    "  thttpd - %ld connections (%g/sec), %d max simultaneous, %lld bytes (%g/sec), %d httpd_conns allocated",
+	    "  thttpd - %ld connections (%g/sec), %d max simultaneous, %ld bytes (%g/sec), %d httpd_conns allocated",
 	    stats_connections, (float) stats_connections / secs,
 	    stats_simultaneous, (int64_t) stats_bytes,
 	    (float) stats_bytes / secs, httpd_conn_count );


### PR DESCRIPTION
This fixes some simple gcc printf warnings.

AC_USE_SYSTEM_EXTENSIONS - enables _XOPEN_SOURCE macro for sigset