### PR TITLE
Include code and policy for AppArmor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,12 @@ AC_PROG_AR
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_LIB(rt, clock_gettime)
 AC_CHECK_LIB(resolv, hstrerror)
-PKG_CHECK_MODULES([APPARMOR], [libapparmor], [AC_DEFINE([HAVE_APPARMOR],[1],[Use Apparmor])])
+
+# Apparmor
+AC_ARG_WITH([apparmor], AS_HELP_STRING([--with-apparmor], [Build with support for AppArmor]))
+AS_IF([test "x$with_apparmor" = "xyes"], [
+	PKG_CHECK_MODULES([APPARMOR], [libapparmor], [AC_DEFINE([HAVE_APPARMOR],[1],[Use Apparmor])])
+])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h grp.h memory.h netdb.h netinet/in.h osreldate.h paths.h poll.h stdlib.h string.h sys/devpoll.h sys/event.h sys/param.h sys/poll.h sys/socket.h sys/time.h syslog.h unistd.h])

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,7 @@ AC_PROG_AR
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_LIB(rt, clock_gettime)
 AC_CHECK_LIB(resolv, hstrerror)
+PKG_CHECK_MODULES([APPARMOR], [libapparmor], [AC_DEFINE([HAVE_APPARMOR],[1],[Use Apparmor])])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h grp.h memory.h netdb.h netinet/in.h osreldate.h paths.h poll.h stdlib.h string.h sys/devpoll.h sys/event.h sys/param.h sys/poll.h sys/socket.h sys/time.h syslog.h unistd.h])

--- a/dist/apparmor/usr.sbin.thttpd
+++ b/dist/apparmor/usr.sbin.thttpd
@@ -1,0 +1,30 @@
+include <tunables/kernelvars>
+include <tunables/multiarch>
+include <tunables/proc>
+include <tunables/sys>
+include <tunables/home>
+
+/usr/sbin/thttpd {
+	include <abstractions/nameservice>
+	include <abstractions/base>
+	include <abstractions/apparmor_api/change_profile>
+	include <abstractions/apparmor_api/is_enabled>
+
+	capability setuid setgid,
+	capability sys_chroot,
+	capability fsetid chown fowner dac_override,
+	
+	/etc/thttpd/thttpd.conf r,
+	/var/log/thttpd.log rw,
+	/run/thttpd.pid rw,
+	/run/	rw,
+	change_profile -> thttpd_confined,
+
+	profile ^thttpd_confined {
+		/var/www/** rpx,
+		/var/log/thttpd.log w,
+	}
+
+}
+
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,6 @@
+
+AM_CPPFLAGS = $(APPARMOR_CFLAGS)
+
 sbin_PROGRAMS = thttpd
 thttpd_SOURCES = thttpd.c thttpd.h \
 	fdwatch.c fdwatch.h \
@@ -6,7 +9,7 @@ thttpd_SOURCES = thttpd.c thttpd.h \
 	timers.c timers.h \
 	tdate_parse.c tdate_parse.h \
 	mime_encodings.h mime_types.h version.h
-thttpd_LDADD = libmatch.a
+thttpd_LDADD = libmatch.a $(APPARMOR_LIBS)
 
 noinst_LIBRARIES = libmatch.a
 libmatch_a_SOURCES = match.c match.h

--- a/src/thttpd.c
+++ b/src/thttpd.c
@@ -59,6 +59,10 @@
 #include <timers.h>
 #include <version.h>
 
+#ifdef HAVE_APPARMOR
+#include <sys/apparmor.h>
+#endif
+
 #ifndef SHUT_WR
 #define SHUT_WR 1
 #endif
@@ -713,6 +717,20 @@ main( int argc, char** argv )
 		LOG_WARNING,
 		"started as root without requesting chroot(), warning only" );
 	}
+
+    /* Drop to another profile after binding to stuff */
+#ifdef HAVE_APPARMOR
+    if ( aa_is_enabled() )
+        {
+        if( aa_change_profile( "thttpd_confined" ) < 0 )
+            {
+	    syslog(
+		LOG_WARNING,
+		"could not change the AppArmor profile - %m" );
+            perror("aa_change_profile ");
+            }
+        }
+#endif
 
     /* Initialize our connections table. */
     connects = NEW( connecttab, max_connects );


### PR DESCRIPTION
What this patch does is it includes a policy for AppArmor (inside a new `dist/apparmor` subfolder, which might not be correct) and it lets the process drop its privileges before processing requests, after all the bind(2)-ing and chroot(2)-ing etc. is done.

I'm also not sure whether it makes more sense to include this in the code-repo, or to distribute this as patches in e.g. portage.