### PR TITLE
typo found on shell script

### DIFF
--- a/extras/syslogtocern
+++ b/extras/syslogtocern
@@ -2,7 +2,7 @@
 #
 # syslogtocern - convert thttpd syslog entries into CERN Combined Log Format
 #
-# Copyright © 1995,1998 by Jef Poskanzer <jef@mail.acme.com>.
+# Copyright Â© 1995,1998 by Jef Poskanzer <jef@mail.acme.com>.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,7 @@ if [ $# -lt 1 ] ; then
     exit 1
 fi
 
-tmp1=``mktemp -t stc1.XXXXXX` || { echo "$0: Cannot create temporary file" >&2; exit 1;  }
+tmp1=`mktemp -t stc1.XXXXXX` || { echo "$0: Cannot create temporary file" >&2; exit 1;  }
 trap " [ -f \"$tmp1\" ] && /bin/rm -f -- \"$tmp1\"" 0 1 2 3 13 15
 
 # Gather up all the thttpd entries.


### PR DESCRIPTION
See line 34. You tried to do command substitution but you accidentally typed two "`"s. I fixed.

Also sorry for changing encoding from ISO-8859-1 to UTF-8; I edited from GitHub and automatically converted.