### PR TITLE
Define _GNU_SOURCE if HAVE_SIGSET is set

### DIFF
--- a/src/libhttpd.c
+++ b/src/libhttpd.c
@@ -25,8 +25,11 @@
 ** SUCH DAMAGE.
 */
 
-
 #include <config.h>
+
+#ifdef HAVE_SIGSET
+#define _GNU_SOURCE
+#endif
 
 //system headers
 #include <sys/types.h>

--- a/src/thttpd.c
+++ b/src/thttpd.c
@@ -28,6 +28,10 @@
 
 #include <config.h>
 
+#ifdef HAVE_SIGSET
+#define _GNU_SOURCE
+#endif
+
 //system headers
 #include <sys/param.h>
 #include <sys/types.h>


### PR DESCRIPTION
This enforces using sigset() API which needs _GNU_SOURCE macro to be defined

Signed-off-by: Khem Raj <raj.khem@gmail.com>